### PR TITLE
Added support for Linux on power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ services:
 env:
 - OS=centos
 - OS=opensuse
+arch:
+  - ppc64le
+  - amd64
 install:
 - ./pkg/build-dockerfile.sh $OS
 script:


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/ujjwalsh/sassist-1/builds/182789333

Please have a look.

Regards,
ujjwal